### PR TITLE
Switch admin auth to cookies

### DIFF
--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -22,30 +22,17 @@ export default function AdminDashboard() {
   const router = useRouter();
 
   useEffect(() => {
-    // Check if user is authenticated
-    const token = localStorage.getItem('adminToken');
-    if (!token) {
-      router.push('/admin/login');
-      return;
-    }
-
-    // Fetch contact submissions
+    // Attempt to fetch submissions; if unauthorized the API will respond with 401
     fetchSubmissions();
   }, [router]);
 
   const fetchSubmissions = async () => {
     try {
-      const token = localStorage.getItem('adminToken');
-      const response = await fetch('/api/admin/submissions', {
-        headers: {
-          'Authorization': `Bearer ${token}`
-        }
-      });
+      const response = await fetch('/api/admin/submissions');
 
       if (!response.ok) {
         if (response.status === 401) {
           // Token expired or invalid
-          localStorage.removeItem('adminToken');
           router.push('/admin/login');
           return;
         }
@@ -62,19 +49,17 @@ export default function AdminDashboard() {
     }
   };
 
-  const handleLogout = () => {
-    localStorage.removeItem('adminToken');
+  const handleLogout = async () => {
+    await fetch('/api/auth', { method: 'DELETE' });
     router.push('/admin/login');
   };
 
   const updateSubmissionStatus = async (id: number, status: string) => {
     try {
-      const token = localStorage.getItem('adminToken');
       const response = await fetch(`/api/admin/submissions/${id}`, {
         method: 'PATCH',
         headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
+          'Content-Type': 'application/json'
         },
         body: JSON.stringify({ status })
       });

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -38,10 +38,7 @@ export default function AdminLogin() {
         throw new Error(data.error || 'Login failed');
       }
 
-      // Store token in localStorage
-      localStorage.setItem('adminToken', data.token);
-      
-      // Redirect to admin dashboard
+      // Successful login will set httpOnly cookie
       router.push('/admin/dashboard');
     } catch (error) {
       console.error('Login error:', error);

--- a/src/app/api/admin/submissions/[id]/route.ts
+++ b/src/app/api/admin/submissions/[id]/route.ts
@@ -9,12 +9,19 @@ const JWT_SECRET = process.env.JWT_SECRET || 'glodinas-finance-secret-key';
 // Middleware to verify JWT token
 const verifyToken = (request: NextRequest) => {
   try {
+    let token: string | undefined | null = null;
+
     const authHeader = request.headers.get('authorization');
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    if (authHeader && authHeader.startsWith('Bearer ')) {
+      token = authHeader.split(' ')[1];
+    } else {
+      token = request.cookies.get('adminToken')?.value;
+    }
+
+    if (!token) {
       return null;
     }
-    
-    const token = authHeader.split(' ')[1];
+
     return jwt.verify(token, JWT_SECRET);
   } catch (error) {
     return null;

--- a/src/app/api/admin/submissions/route.ts
+++ b/src/app/api/admin/submissions/route.ts
@@ -9,12 +9,19 @@ const JWT_SECRET = process.env.JWT_SECRET || 'glodinas-finance-secret-key';
 // Middleware to verify JWT token
 const verifyToken = (request: NextRequest) => {
   try {
+    let token: string | undefined | null = null;
+
     const authHeader = request.headers.get('authorization');
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    if (authHeader && authHeader.startsWith('Bearer ')) {
+      token = authHeader.split(' ')[1];
+    } else {
+      token = request.cookies.get('adminToken')?.value;
+    }
+
+    if (!token) {
       return null;
     }
-    
-    const token = authHeader.split(' ')[1];
+
     return jwt.verify(token, JWT_SECRET);
   } catch (error) {
     return null;

--- a/src/app/api/auth/route.ts
+++ b/src/app/api/auth/route.ts
@@ -47,8 +47,18 @@ export async function POST(request: NextRequest) {
       JWT_SECRET,
       { expiresIn: '24h' }
     );
-    
-    return NextResponse.json({ token });
+
+    const response = NextResponse.json({ success: true });
+    response.cookies.set({
+      name: 'adminToken',
+      value: token,
+      httpOnly: true,
+      sameSite: 'strict',
+      secure: process.env.NODE_ENV === 'production',
+      maxAge: 60 * 60 * 24, // 24 hours
+      path: '/',
+    });
+    return response;
   } catch (error) {
     console.error('Authentication error:', error);
     return NextResponse.json(
@@ -56,4 +66,15 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+export async function DELETE() {
+  const response = NextResponse.json({ success: true });
+  response.cookies.set({
+    name: 'adminToken',
+    value: '',
+    path: '/',
+    expires: new Date(0),
+  });
+  return response;
 }


### PR DESCRIPTION
## Summary
- issue JWT cookies on login and handle logout in auth route
- update admin login to rely on cookie
- use cookie authentication in dashboard and admin API routes

## Testing
- `npx next lint` *(fails: various lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68480d1df6c0832488ed0c05f0ca7b98