### PR TITLE
Remove secret fallbacks and validate environment

### DIFF
--- a/src/app/api/admin/setup/route.ts
+++ b/src/app/api/admin/setup/route.ts
@@ -2,6 +2,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { PrismaClient } from '@prisma/client';
 import bcrypt from 'bcryptjs';
+import env from '@/lib/env';
 
 const prisma = new PrismaClient();
 
@@ -13,7 +14,7 @@ export async function POST(request: NextRequest) {
     const { username, password, setupKey } = body;
     
     // Verify setup key (this should be a strong, unique key known only to the site owner)
-    const expectedSetupKey = process.env.ADMIN_SETUP_KEY || 'glodinas-finance-initial-setup-key';
+    const expectedSetupKey = env.ADMIN_SETUP_KEY;
     if (setupKey !== expectedSetupKey) {
       return NextResponse.json(
         { error: 'Invalid setup key' },

--- a/src/app/api/admin/submissions/[id]/route.ts
+++ b/src/app/api/admin/submissions/[id]/route.ts
@@ -2,9 +2,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { PrismaClient } from '@prisma/client';
 import jwt from 'jsonwebtoken';
+import env from '@/lib/env';
 
 const prisma = new PrismaClient();
-const JWT_SECRET = process.env.JWT_SECRET || 'glodinas-finance-secret-key';
+const { JWT_SECRET } = env;
 
 // Middleware to verify JWT token
 const verifyToken = (request: NextRequest) => {

--- a/src/app/api/admin/submissions/route.ts
+++ b/src/app/api/admin/submissions/route.ts
@@ -2,9 +2,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { PrismaClient } from '@prisma/client';
 import jwt from 'jsonwebtoken';
+import env from '@/lib/env';
 
 const prisma = new PrismaClient();
-const JWT_SECRET = process.env.JWT_SECRET || 'glodinas-finance-secret-key';
+const { JWT_SECRET } = env;
 
 // Middleware to verify JWT token
 const verifyToken = (request: NextRequest) => {

--- a/src/app/api/auth/route.ts
+++ b/src/app/api/auth/route.ts
@@ -3,9 +3,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { PrismaClient } from '@prisma/client';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
+import env from '@/lib/env';
 
 const prisma = new PrismaClient();
-const JWT_SECRET = process.env.JWT_SECRET || 'glodinas-finance-secret-key';
+const { JWT_SECRET } = env;
 
 export async function POST(request: NextRequest) {
   try {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import I18nProvider from "@/components/I18nProvider";
+import "@/lib/env"; // Validate required environment variables on startup
 
 const inter = Inter({ subsets: ["latin"] });
 

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,27 @@
+const requiredVars = [
+  'JWT_SECRET',
+  'ADMIN_SETUP_KEY',
+  'MAILTRAP_API_TOKEN',
+  'MONEYBIRD_CLIENT_ID',
+  'MONEYBIRD_CLIENT_SECRET',
+  'NEXT_PUBLIC_BASE_URL',
+];
+
+for (const name of requiredVars) {
+  if (!process.env[name]) {
+    throw new Error(`Environment variable ${name} is required but not defined`);
+  }
+}
+
+const env = {
+  JWT_SECRET: process.env.JWT_SECRET as string,
+  ADMIN_SETUP_KEY: process.env.ADMIN_SETUP_KEY as string,
+  MAILTRAP_API_TOKEN: process.env.MAILTRAP_API_TOKEN as string,
+  MONEYBIRD_CLIENT_ID: process.env.MONEYBIRD_CLIENT_ID as string,
+  MONEYBIRD_CLIENT_SECRET: process.env.MONEYBIRD_CLIENT_SECRET as string,
+  NEXT_PUBLIC_BASE_URL: process.env.NEXT_PUBLIC_BASE_URL as string,
+  NOTIFICATION_EMAIL: process.env.NOTIFICATION_EMAIL,
+  EMAIL_FROM: process.env.EMAIL_FROM,
+};
+
+export default env;


### PR DESCRIPTION
## Summary
- require key env vars on startup via new `env` helper
- import `env` in layout to run validation early
- use `env` helper in API routes instead of secret fallbacks

## Testing
- `npm install`
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68480d0811d48324ab83cb0af99a6313