### PR TITLE
Configure admin creation script via env or args

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,19 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Creating the admin user
+
+The project includes a script to create the initial admin account. Pass the
+credentials either as CLI arguments or environment variables:
+
+```bash
+# using arguments
+node src/scripts/create-admin.js admin@example.com StrongPassword123
+
+# using environment variables
+ADMIN_USERNAME=admin@example.com ADMIN_PASSWORD=StrongPassword123 \
+  node src/scripts/create-admin.js
+```
+
+If the username or password is missing, the script exits with an error message.

--- a/src/scripts/create-admin.js
+++ b/src/scripts/create-admin.js
@@ -5,10 +5,21 @@ const bcrypt = require('bcryptjs');
 const prisma = new PrismaClient();
 
 async function createAdmin() {
+  const username = process.argv[2] || process.env.ADMIN_USERNAME;
+  const password = process.argv[3] || process.env.ADMIN_PASSWORD;
+
+  if (!username || !password) {
+    console.error(
+      'Error: admin username and password are required.\n' +
+        'Provide them as CLI arguments or via the ADMIN_USERNAME and ADMIN_PASSWORD environment variables.'
+    );
+    process.exit(1);
+  }
+
   try {
     // Check if admin already exists
     const existingAdmin = await prisma.admin.findUnique({
-      where: { username: 'cihatkaya@glodinas.nl' },
+      where: { username },
     });
     
     if (existingAdmin) {
@@ -17,15 +28,15 @@ async function createAdmin() {
     }
     
     // Hash password
-    const hashedPassword = await bcrypt.hash('Galati123', 10);
+  const hashedPassword = await bcrypt.hash(password, 10);
     
     // Create admin user
-    const admin = await prisma.admin.create({
-      data: {
-        username: 'cihatkaya@glodinas.nl',
-        password: hashedPassword,
-      },
-    });
+  const admin = await prisma.admin.create({
+    data: {
+      username,
+      password: hashedPassword,
+    },
+  });
     
     console.log('Admin user created successfully:', {
       id: admin.id,

--- a/src/scripts/create-admin.ts
+++ b/src/scripts/create-admin.ts
@@ -5,10 +5,21 @@ import bcrypt from 'bcryptjs';
 const prisma = new PrismaClient();
 
 async function createAdmin() {
+  const username = process.argv[2] || process.env.ADMIN_USERNAME;
+  const password = process.argv[3] || process.env.ADMIN_PASSWORD;
+
+  if (!username || !password) {
+    console.error(
+      'Error: admin username and password are required.\n' +
+        'Provide them as CLI arguments or via the ADMIN_USERNAME and ADMIN_PASSWORD environment variables.'
+    );
+    process.exit(1);
+  }
+
   try {
     // Check if admin already exists
     const existingAdmin = await prisma.admin.findUnique({
-      where: { username: 'cihatkaya@glodinas.nl' },
+      where: { username },
     });
     
     if (existingAdmin) {
@@ -17,15 +28,15 @@ async function createAdmin() {
     }
     
     // Hash password
-    const hashedPassword = await bcrypt.hash('Galati123', 10);
+    const hashedPassword = await bcrypt.hash(password, 10);
     
     // Create admin user
-    const admin = await prisma.admin.create({
-      data: {
-        username: 'cihatkaya@glodinas.nl',
-        password: hashedPassword,
-      },
-    });
+      const admin = await prisma.admin.create({
+        data: {
+          username,
+          password: hashedPassword,
+        },
+      });
     
     console.log('Admin user created successfully:', {
       id: admin.id,


### PR DESCRIPTION
## Summary
- let the admin creation scripts read credentials from CLI args or env vars
- document how to run the admin creation script

## Testing
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68480cf2ef9c8324a62f2000aea29321